### PR TITLE
Remove the use of test data as validation data

### DIFF
--- a/dna/__main__.py
+++ b/dna/__main__.py
@@ -174,7 +174,7 @@ def evaluate(
     ootsp_test_data: typing.Dict = None, *, verbose: bool = False, model_output_dir: str = None, plot_dir: str = None
 ):
     train_predictions, fit_time, train_predict_time = problem.fit_predict(
-        train_data, test_data, model, model_config, verbose=verbose, model_output_dir=model_output_dir
+        train_data, model, model_config, verbose=verbose, model_output_dir=model_output_dir
     )
     train_scores = problem.score(train_predictions, train_data)
 

--- a/dna/problems.py
+++ b/dna/problems.py
@@ -27,7 +27,7 @@ class ProblemBase:
             )
 
     def fit(
-        self, train_data, test_data, model, model_config, *, refit_model=False, verbose=False, model_output_dir=None
+        self, train_data, model, model_config, *, refit_model=False, verbose=False, model_output_dir=None
     ):
         self._validate_model_has_method(model, self._fit_method_name)
 
@@ -38,7 +38,7 @@ class ProblemBase:
         if not model.fitted or refit_model:
             start_time = time.time()
             model_fit_method(
-                train_data, validation_data=test_data, verbose=verbose, output_dir=model_output_dir, **model_fit_config
+                train_data, verbose=verbose, output_dir=model_output_dir, **model_fit_config
             )
             fit_time = time.time() - start_time
 
@@ -57,10 +57,10 @@ class ProblemBase:
         return predictions, predict_time
 
     def fit_predict(
-        self, train_data, test_data, model, model_config, *, refit_model=False, verbose=False, model_output_dir=None
+        self, train_data, model, model_config, *, refit_model=False, verbose=False, model_output_dir=None
     ):
         fit_time = self.fit(
-            train_data, test_data, model, model_config, refit_model=refit_model, verbose=verbose, model_output_dir=model_output_dir
+            train_data, model, model_config, refit_model=refit_model, verbose=verbose, model_output_dir=model_output_dir
         )
 
         train_predictions, predict_time = self.predict(


### PR DESCRIPTION
This addresses the machine learning bug in #98. The test data is no longer used as validation data. This does not resolve the issue of implementing early stopping.