### PR TITLE
Bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ data/*.json
 env/
 dev_results/
 rescore/
-.cache
+.cache/
+tmp/

--- a/dna/metrics.py
+++ b/dna/metrics.py
@@ -26,11 +26,21 @@ def pearson_correlation(y_hat, y):
 
 
 def top_k_correct(top_k_predicted: typing.Sequence, actual_data: pd.DataFrame, k: int):
+    """
+    Assumes that the top_k_predicted list is sorted. 
+    """
+    top_k_predicted = top_k_predicted[:k]
+    assert len(top_k_predicted) <= k, "The number of pipelines given is more than K: {} vs {}".format(len(top_k_predicted), k)
     top_actual = actual_data.nlargest(k, columns='test_f1_macro', keep='all')['pipeline_id']
     return len(set(top_actual).intersection(set(top_k_predicted)))
 
 
 def top_k_regret(top_k_predicted: typing.Sequence, actual_data: pd.DataFrame, k: int):
+    """
+    Assumes that the top_k_predicted list is sorted. 
+    """
+    top_k_predicted = top_k_predicted[:k]
+    assert len(top_k_predicted) <= k, "The number of pipelines given is more than K: {} vs {}".format(len(top_k_predicted), k)
     actual_best_score = actual_data['test_f1_macro'].max()
     min_regret = float('inf')
     for pipeline_id in top_k_predicted:

--- a/dna/metrics.py
+++ b/dna/metrics.py
@@ -30,7 +30,7 @@ def top_k_correct(top_k_predicted: typing.Sequence, actual_data: pd.DataFrame, k
     Assumes that the top_k_predicted list is sorted. 
     """
     top_k_predicted = top_k_predicted[:k]
-    assert len(top_k_predicted) <= k, "The number of pipelines given is more than K: {} vs {}".format(len(top_k_predicted), k)
+    assert len(top_k_predicted) <= k, 'length of top_k_predicted ({}) is greater than k ({})'.format(len(top_k_predicted), k)
     top_actual = actual_data.nlargest(k, columns='test_f1_macro', keep='all')['pipeline_id']
     return len(set(top_actual).intersection(set(top_k_predicted)))
 
@@ -40,7 +40,7 @@ def top_k_regret(top_k_predicted: typing.Sequence, actual_data: pd.DataFrame, k:
     Assumes that the top_k_predicted list is sorted. 
     """
     top_k_predicted = top_k_predicted[:k]
-    assert len(top_k_predicted) <= k, "The number of pipelines given is more than K: {} vs {}".format(len(top_k_predicted), k)
+    assert len(top_k_predicted) <= k, 'length of top_k_predicted ({}) is greater than k ({})'.format(len(top_k_predicted), k)
     actual_best_score = actual_data['test_f1_macro'].max()
     min_regret = float('inf')
     for pipeline_id in top_k_predicted:

--- a/dna/models/baselines.py
+++ b/dna/models/baselines.py
@@ -137,7 +137,7 @@ class MetaAutoSklearn(SklearnBase):
 
     def __init__(self, seed=0, **kwargs):
         super().__init__(seed=seed)
-        self.regressor = autosklearn.AutoSklearnRegressor(seed=seed, **kwargs)
+        self.regressor = autosklearn.AutoSklearnRegressor(seed=seed, **kwargs, tmp_folder="./tmp")
         self.fitted = False
 
 

--- a/dna/models/baselines.py
+++ b/dna/models/baselines.py
@@ -137,7 +137,7 @@ class MetaAutoSklearn(SklearnBase):
 
     def __init__(self, seed=0, **kwargs):
         super().__init__(seed=seed)
-        self.regressor = autosklearn.AutoSklearnRegressor(seed=seed, **kwargs, tmp_folder="./tmp")
+        self.regressor = autosklearn.AutoSklearnRegressor(seed=seed, **kwargs, tmp_folder='./tmp')
         self.fitted = False
 
 


### PR DESCRIPTION
- Was not using the `k` parameter -> fixes the top-K being the same as the top-1
- Fixes the MetaAutoSKlearn temp bug

This PR assumes that all models are sorting them as it gives them back.  After checking the models, that seems to be true.  Thus, this fix would be the quickest and most efficient computationally, as to not have to "re-predict."

The tmp directory for MetaAutoSKlearn is deleted by default. However, our systems were deleting the system /tmp folder before the 24 hours.

Closes #128, Closes #130