### PR TITLE
Added a config option for using a sequence mask for the encoder

### DIFF
--- a/dna/models/attention_regression_model.py
+++ b/dna/models/attention_regression_model.py
@@ -6,7 +6,7 @@ class AttentionRegressionModel(RNNRegressionRankSubsetModelBase):
 
     def __init__(
         self, n_layers: int, n_heads: int, attention_in_features: int, attention_hidden_features: int,
-        attention_activation_name: str, reduction_name: str, activation_name: str, dropout: float,
+        attention_activation_name: str, reduction_name: str, use_mask: bool, activation_name: str, dropout: float,
         output_n_hidden_layers: int, output_hidden_layer_size: int, use_batch_norm: bool, use_skip: bool, *,
         device: str = 'cuda:0', seed: int = 0
     ):
@@ -21,6 +21,7 @@ class AttentionRegressionModel(RNNRegressionRankSubsetModelBase):
         self.attention_hidden_features = attention_hidden_features
         self.attention_activation_name = attention_activation_name
         self.reduction_name = reduction_name
+        self.use_mask = use_mask
 
     def _get_model(self, train_data):
         n_features = len(train_data[0][self.features_key])
@@ -33,6 +34,7 @@ class AttentionRegressionModel(RNNRegressionRankSubsetModelBase):
             attention_hidden_features=self.attention_hidden_features,
             dropout=self.dropout,
             reduction_name=self.reduction_name,
+            use_mask=self.use_mask,
             mlp_extra_input_size=n_features,
             mlp_hidden_layer_size=self.output_hidden_layer_size,
             mlp_n_hidden_layers=self.output_n_hidden_layers,

--- a/model_configs/attention_regression_config.json
+++ b/model_configs/attention_regression_config.json
@@ -4,6 +4,7 @@
     "use_batch_norm": true,
     "use_skip": false,
     "dropout": 0.5,
+    "use_mask": true,
 
     "n_layers": 6,
     "n_heads": 4,


### PR DESCRIPTION
The encoder has an option for inputting a mask into its forward function. This mask tells the model the ordering of the inputs in the sequence. Having an option for using this mask in the config for the attention regression model could be a useful hyperparameter to tune.