### PR TITLE
Added a rm directory command at the end of the meta autosklearn portion of main.sh

### DIFF
--- a/dna/models/baselines.py
+++ b/dna/models/baselines.py
@@ -1,8 +1,10 @@
+import os
+import shutil
+
 import autosklearn.regression as autosklearn
 import numpy as np
 import pandas as pd
 from sklearn import linear_model
-import os
 
 from .base_models import RankModelBase, RegressionModelBase, SklearnBase, SubsetModelBase
 from dna import utils
@@ -141,7 +143,8 @@ class MetaAutoSklearn(SklearnBase):
 
         tmp_dir = './tmp'
         if os.path.isdir(tmp_dir):
-            os.system('rm -r {}'.format(tmp_dir))
+            shutil.rmtree(tmp_dir)
+
         self.regressor = autosklearn.AutoSklearnRegressor(seed=seed, **kwargs, tmp_folder=tmp_dir)
         self.fitted = False
 

--- a/dna/models/baselines.py
+++ b/dna/models/baselines.py
@@ -2,6 +2,7 @@ import autosklearn.regression as autosklearn
 import numpy as np
 import pandas as pd
 from sklearn import linear_model
+import os
 
 from .base_models import RankModelBase, RegressionModelBase, SklearnBase, SubsetModelBase
 from dna import utils
@@ -137,7 +138,11 @@ class MetaAutoSklearn(SklearnBase):
 
     def __init__(self, seed=0, **kwargs):
         super().__init__(seed=seed)
-        self.regressor = autosklearn.AutoSklearnRegressor(seed=seed, **kwargs, tmp_folder='./tmp')
+
+        tmp_dir = './tmp'
+        if os.path.isdir(tmp_dir):
+            os.system('rm -r {}'.format(tmp_dir))
+        self.regressor = autosklearn.AutoSklearnRegressor(seed=seed, **kwargs, tmp_folder=tmp_dir)
         self.fitted = False
 
 

--- a/main.sh
+++ b/main.sh
@@ -107,7 +107,6 @@ python3 -m dna evaluate \
     --output-dir $results_dir \
     --verbose \
     $use_ootsp
-rm -r ./tmp
 
 
 python3 -m dna evaluate \

--- a/main.sh
+++ b/main.sh
@@ -107,6 +107,7 @@ python3 -m dna evaluate \
     --output-dir $results_dir \
     --verbose \
     $use_ootsp
+rm -r ./tmp
 
 
 python3 -m dna evaluate \


### PR DESCRIPTION
The autosklearn package has begun a new behavior where it creates a ./tmp directory but doesn't delete it. When we want to run autosklearn again, it attempts to create this directory but the directory already exists from the previous run, thus causing a run time error. The directory is completely empty by the time the run is over. I have no idea what caused this new behavior but the solution is simply deleting that tmp directory between runs.