### PR TITLE
Build metadataset from D3M DB data

### DIFF
--- a/dna/utils.py
+++ b/dna/utils.py
@@ -78,3 +78,26 @@ class NumpyJSONEncoder(json.JSONEncoder):
         if isinstance(obj, np.ndarray):
             return obj.tolist()
         return json.JSONEncoder.default(self, obj)
+
+
+def has_path(data, path) -> bool:
+    """
+    Returns `True` if `data` has the key path identified
+    by `path`. The keys can be dictionary keys or list/tuple
+    indices.
+    """
+    walk = data
+    for key in path:
+        if isinstance(walk, dict):
+            if key in walk:
+                walk = walk[key]
+            else:
+                return False
+        elif isinstance(walk, list) or isinstance(walk, tuple):
+            if isinstance(key, int) and key < len(walk):
+                walk = walk[key]
+            else:
+                return False
+        else:
+            return False
+    return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ pandas==0.25.0
 Pillow==6.1.0
 psutil==5.6.3
 Pygments==2.4.2
+pymongo==3.10.1
 pynisher==0.5.0
 pyparsing==2.4.1.1
 pyrfr==0.7.4

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -47,7 +47,7 @@ class UtilsTestCase(unittest.TestCase):
         self.assertEqual(expected_flattened, flattened)
         self.assertEqual(utils.inflate(expected_flattened), to_flatten)
 
-    def transpose_jagged_2darray(self):
+    def test_transpose_jagged_2darray(self):
         jagged_2darray = [
             [0, 1],
             [2, 3, 4],
@@ -62,3 +62,11 @@ class UtilsTestCase(unittest.TestCase):
         }
         transpose = utils.transpose_jagged_2darray(jagged_2darray)
         self.assertEqual(desired_transpose, transpose)
+    
+    def test_has_path(self):
+        data = {"a": {"b": ["c"]}}
+        self.assertTrue(utils.has_path(data, ["a", "b", 0]))
+        self.assertFalse(utils.has_path(data, ["a", "b", 1]))
+        self.assertFalse(utils.has_path(data, ["a", "b", "c"]))
+        self.assertFalse(utils.has_path(data, ["y", "z"]))
+


### PR DESCRIPTION
In this PR, the `dna.database_to_json` module is altered to read data from our lab's local mirror of the D3M MtL DB. Also, a few things are made more robust, to handle the greater variety that exists among pipeline runs in the D3M MtL DB (like problem documents using different schemas). With this PR, we can now include TA2 submitted pipeline runs in our metadataset.