### PR TITLE
One hot encoding of primitives should support unseen primitives

### DIFF
--- a/dna/constants.py
+++ b/dna/constants.py
@@ -1,0 +1,1 @@
+UNKNOWN = "unknown"

--- a/dna/data.py
+++ b/dna/data.py
@@ -9,6 +9,8 @@ import pandas as pd
 import torch
 import torch.utils.data
 
+from dna import constants
+
 
 def group_json_objects(json_objects, group_key):
     """
@@ -523,10 +525,10 @@ class RNNDataLoader(GroupDataLoader):
         encoding = []
         for primitive in pipeline:
             primitive_name = primitive[prim_name_key]
-            try:
+            if primitive_name in primitive_to_enc:
                 encoded_primitive = primitive_to_enc[primitive_name]
-            except():
-                raise KeyError('A primitive in this data set is not in the primitive encoding')
+            else:
+                encoded_primitive = primitive_to_enc[constants.UNKNOWN]
 
             encoding.append(encoded_primitive)
         return encoding

--- a/dna/models/base_models.py
+++ b/dna/models/base_models.py
@@ -337,7 +337,10 @@ class SklearnBase(RegressionModelBase, RankModelBase):
         for primitive in pipeline[self.steps_key]:
             primitive_name = primitive[self.prim_name_key]
             # get the position of the one hot encoding
-            primitive_index = np.argmax(self.one_hot_primitives_map[primitive_name])
+            if primitive_name in self.one_hot_primitives_map:
+                primitive_index = np.argmax(self.one_hot_primitives_map[primitive_name])
+            else:
+                primitive_index = np.argmax(self.one_hot_primitives_map[constants.UNKNOWN])
             encoding[primitive_index] = 1
         return encoding
 

--- a/dna/utils.py
+++ b/dna/utils.py
@@ -6,6 +6,8 @@ import git
 import pandas as pd
 import numpy as np
 
+from dna import constants
+
 
 def rank(values: typing.Sequence) -> typing.Sequence:
     return type(values)((pd.Series(values).rank(ascending=False) - 1))
@@ -101,3 +103,30 @@ def has_path(data, path) -> bool:
         else:
             return False
     return True
+
+
+def get_primitive_one_hot_mapping(
+    data, *, pipeline_key: str, steps_key: str, prim_name_key: str
+) -> typing.Tuple[dict, int]:
+    primitive_names = set()
+
+    # Get a set of all the primitives in the data set
+    for instance in data:
+        primitives = instance[pipeline_key][steps_key]
+        for primitive in primitives:
+            primitive_name = primitive[prim_name_key]
+            primitive_names.add(primitive_name)
+        
+    primitive_names = sorted(primitive_names)
+    primitive_names.append(constants.UNKNOWN)  # to handle unseen primitives
+
+    # Get one hot encodings of all the primitives
+    n_primitives = len(primitive_names)
+    encoding = np.identity(n=n_primitives)
+
+    # Create a mapping of primitive names to one hot encodings
+    primitive_name_to_enc = {}
+    for (primitive_name, primitive_encoding) in zip(primitive_names, encoding):
+        primitive_name_to_enc[primitive_name] = primitive_encoding
+
+    return primitive_name_to_enc, n_primitives


### PR DESCRIPTION
Parent issue: #205.

The pipelines in the D3M Metalearning Database use a large variety of primitives. Because of this, there is a chance that when making a train/test split out of a meta dataset curated from the D3M DB, the test split could reference primitives that don't exist in the training set (indeed I ran into this problem). This PR addresses this issue for the sequence models in the repo by including a vector in the one hot encoding primitive matrix for any `unknown` primitives (primitives that the model/data loader did not see in the fit/training phase).

This PR also refactors out a common utility method for creating a primitive one-hot encoding matrix, reducing code duplication in the repo.