### PR TITLE
Ensure training set has all primitives

### DIFF
--- a/dna/__main__.py
+++ b/dna/__main__.py
@@ -57,7 +57,9 @@ def configure_split_parser(parser):
 def split_handler(arguments: argparse.Namespace):
     data_path = getattr(arguments, 'data_path')
     data = get_data(data_path)
-    train_data, test_data = split_data_by_group(data, 'dataset_id', arguments.test_size, arguments.split_seed)
+    train_data, test_data = split_data_by_group(
+        data, 'dataset_id', 'pipeline.steps.name', arguments.test_size, arguments.split_seed
+    )
 
     train_path = getattr(arguments, 'train_path')
     if train_path is None:
@@ -557,7 +559,9 @@ def get_train_and_test_data(
     train_data = get_data(in_train_path)
     if in_test_path is None:
         assert not load_cached_data
-        train_data, test_data = split_data_by_group(train_data, 'dataset_id', test_size, split_seed)
+        train_data, test_data = split_data_by_group(
+            train_data, 'dataset_id', 'pipeline.steps.name', test_size, split_seed
+        )
     else:
         test_data = get_data(in_test_path)
 
@@ -575,6 +579,9 @@ def get_train_and_test_data(
 
 
 def get_ootsp_split_data(train_data, test_data, split_ratio, split_seed):
+    # TODO: Why is `split_ratio` necessary here? It only seems to be
+    # reducing the size of the training data set. Also, when `split_ratio < 1`,
+    # we can no longer ensure that all the primitives are present in the training set.
     train_pipeline_ids = sorted(set(instance['pipeline_id'] for instance in train_data))
     k = int(split_ratio * len(train_pipeline_ids))
 

--- a/dna/models/base_models.py
+++ b/dna/models/base_models.py
@@ -238,7 +238,9 @@ class PyTorchModelBase:
         if validation_ratio == 0:
             return train_data, None
 
-        return split_data_by_group(train_data, 'dataset_id', validation_ratio, split_seed)
+        return split_data_by_group(
+            train_data, 'dataset_id', 'pipeline.steps.name', validation_ratio, split_seed
+        )
 
 
 class PyTorchRegressionRankModelBase(PyTorchModelBase, RegressionModelBase, RankModelBase):

--- a/dna/models/baselines.py
+++ b/dna/models/baselines.py
@@ -249,9 +249,15 @@ class AutoSklearnMetalearner(RegressionModelBase, RankModelBase):
 
     @staticmethod
     def _process_metafeatures(data):
-        metafeatures = pd.DataFrame(data)[['dataset_id', 'metafeatures']].set_index('dataset_id')
-        metafeatures = pd.DataFrame(metafeatures['metafeatures'].tolist(), metafeatures.index)
+        metafeatures = pd.DataFrame(data)
+        # Keep just the dataset_id and metafeatures, and expand each
+        # metafeature out into its own column.
+        metafeatures = pd.concat(
+            [metafeatures.dataset_id, metafeatures.metafeatures.apply(pd.Series)],
+            axis="columns"
+        )
         metafeatures.drop_duplicates(inplace=True)
+        metafeatures.set_index("dataset_id", drop=True, inplace=True)
         return metafeatures
 
 class MLPRegressionModel(PyTorchRegressionRankModelBase):

--- a/dna/utils.py
+++ b/dna/utils.py
@@ -1,6 +1,7 @@
 import collections
 import typing
 import json
+import itertools
 
 import git
 import pandas as pd
@@ -78,6 +79,30 @@ class NumpyJSONEncoder(json.JSONEncoder):
         if isinstance(obj, np.ndarray):
             return obj.tolist()
         return json.JSONEncoder.default(self, obj)
+
+
+def get_values_by_path(data, path: list) -> list:
+    """
+    Retrieves all values in `data` found at `path`, where path is
+    a sequence of keys. If a list data structure is found along the
+    path, the values matching `path` for all elements in the list
+    will be included in the results. 
+    """
+    if len(path) == 0:
+        return [data]
+    elif isinstance(data, (list, tuple)):
+        # Concatenate the results returned by each item in the list.
+        return list(itertools.chain.from_iterable(get_values_by_path(item, path) for item in data))
+    elif isinstance(data, dict):
+        # Descend further down the tree.
+        if path[0] in data:
+            return get_values_by_path(data[path[0]], path[1:])
+        else:
+            return []
+    else:
+        # The path has not been resolved and we've reached a
+        # data type we can't key into, so return no results.
+        return []
 
 
 def has_path(data, path) -> bool:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -70,3 +70,21 @@ class UtilsTestCase(unittest.TestCase):
         self.assertFalse(utils.has_path(data, ["a", "b", "c"]))
         self.assertFalse(utils.has_path(data, ["y", "z"]))
 
+    def test_get_values_by_path(self):
+        data_with_list = {"a": [{"b": 1}, {"b": 2}, {"b": 3}]}
+        self.assertEqual([1,2,3], utils.get_values_by_path(data_with_list, ["a", "b"]))
+
+        partial_data = {"a": {"b": [{"c": 1}, {"d": 2}, {"c": 3}]}}
+        self.assertEqual([1,3], utils.get_values_by_path(partial_data, ["a", "b", "c"]))
+
+        long_data = {"a": [{"b": {"c": {"d": 1}}}, {"b": {"c": {"d": 1}}}]}
+        self.assertEqual([1,1], utils.get_values_by_path(long_data, ["a", "b", "c", "d"]))
+
+        uneven_depth_data = {"a": {"b": [{"c": 1}, 2, {"c": 3}]}}
+        self.assertEqual([1,3], utils.get_values_by_path(uneven_depth_data, ["a", "b", "c"]))
+
+        list_data = [{"a": {"b": 1}}, {"a": {"b": 2}}, {"a": {"b": 3}}]
+        self.assertEqual([1,2,3], utils.get_values_by_path(list_data, ["a", "b"]))
+
+        nested_lists_data = [{"a": [{"b": 1}, {"b": 1}]}, {"a": [{"b": 1}, {"b": 1}]}]
+        self.assertEqual([1,1,1,1], utils.get_values_by_path(nested_lists_data, ["a", "b"]))


### PR DESCRIPTION
This PR ensures a training data set includes all primitives found in the full dataset, while still ensuring that the train/test split is otherwise as random as possible. This prevents errors related to models running into unseen primitives at test time.

This PR also ensures that when using the `autosklearn` metamodel, all datasets and their metafeatures are preserved in the metadataset.